### PR TITLE
arm64: dts: qcom: x1p42100-ideapad-slim5x: Fix display brightness regression

### DIFF
--- a/arch/arm64/boot/dts/qcom/x1p42100-lenovo-ideapad-slim5x-oled.dts
+++ b/arch/arm64/boot/dts/qcom/x1p42100-lenovo-ideapad-slim5x-oled.dts
@@ -307,6 +307,7 @@
 		pinctrl-names = "default";
 
 		regulator-boot-on;
+		regulator-always-on;
 	};
 
 	vreg_misc_3p3: regulator-misc-3p3 {


### PR DESCRIPTION
I have the ideapad slim5x OLED variant and the display brightness control stopped working on kernels newer than `6.19.6-jg-0-qcom-x1e`. 

I compared the dmesg logs and in newer kernel versions the regulator `VREG_EDP_3P3` is being disabled, which breaks the brightness control (it gets stuck at full brightness):
```
[   30.695587] VREG_EDP_3P3: disabling
```
The PR fixes the issue by making sure that the regulator is always on.  I have tested the fix by building my own devicetree and using `flash-kernel` to install it and the brightness control works with newer kernels now.

Disclaimer: I used Claude to analyze the logs and it suggested the fix.