### PR TITLE
SP11: fix volume-down replay and preserve 7.2.2 GPI/SPI behavior

### DIFF
--- a/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi
+++ b/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi
@@ -1529,9 +1529,3 @@
 &cluster_pd2 {
 	domain-idle-states = <>;
 };
-
-&pon_resin {
-	linux,code = <KEY_VOLUMEDOWN>;
-
-	status = "okay";
-};

--- a/debian.qcom-x1e/changelog
+++ b/debian.qcom-x1e/changelog
@@ -1,3 +1,11 @@
+linux-qcom-x1e (7.2.2-jg-0sp11v21) resolute; urgency=medium
+
+  * Fix the Denali volume-down replay by leaving pon_resin disabled.
+  * Preserve the GPI DMA_PRIVATE capability and GENI SPI tracepoints in the
+    SP11 QSPI port.
+
+ -- Leon Silcott <leon@boasi.io>  Mon, 31 Aug 2026 14:15:14 +0100
+
 linux-qcom-x1e (7.2.2-jg-0sp11v20) resolute; urgency=medium
 
   * rebased the PR onto jg/ubunt-qcom-x1e-7.2.y

--- a/drivers/dma/qcom/gpi.c
+++ b/drivers/dma/qcom/gpi.c
@@ -2747,6 +2747,7 @@ static int gpi_probe(struct platform_device *pdev)
 	/* clear and Set capabilities */
 	dma_cap_zero(gpi_dev->dma_device.cap_mask);
 	dma_cap_set(DMA_SLAVE, gpi_dev->dma_device.cap_mask);
+	dma_cap_set(DMA_PRIVATE, gpi_dev->dma_device.cap_mask);
 
 	/* configure dmaengine apis */
 	gpi_dev->dma_device.directions = BIT(DMA_DEV_TO_MEM) | BIT(DMA_MEM_TO_DEV);

--- a/drivers/spi/spi-geni-qcom.c
+++ b/drivers/spi/spi-geni-qcom.c
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
 // Copyright (c) 2017-2018, The Linux foundation. All rights reserved.
 
+#define CREATE_TRACE_POINTS
+#include <trace/events/qcom_geni_spi.h>
+
 #include <linux/clk.h>
 #include <linux/delay.h>
 #include <linux/dmaengine.h>
@@ -463,6 +466,9 @@ static int geni_spi_set_clock_and_bw(struct spi_geni_master *mas,
 	writel(clk_sel, se->base + SE_GENI_CLK_SEL);
 	writel(m_clk_cfg, se->base + GENI_SER_M_CLK_CFG);
 
+	trace_geni_spi_clk_cfg(mas->dev, clk_hz, mas->cur_sclk_hz, idx, div,
+			       mas->cur_bits_per_word);
+
 	/* Set BW quota for CPU as driver supports FIFO mode only. */
 	se->icc_paths[CPU_TO_GENI].avg_bw = Bps_to_icc(mas->cur_speed_hz);
 	ret = geni_icc_set_bw(se);
@@ -496,6 +502,9 @@ static int setup_fifo_params(struct spi_device *spi_slv,
 		writel((spi_slv->mode & SPI_CPOL) ? CPOL : 0, se->base + SE_SPI_CPOL);
 	if ((mode_changed & SPI_CS_HIGH) || (cs_changed && (spi_slv->mode & SPI_CS_HIGH)))
 		writel((spi_slv->mode & SPI_CS_HIGH) ? BIT(chipselect) : 0, se->base + SE_SPI_DEMUX_OUTPUT_INV);
+
+	trace_geni_spi_setup_params(mas->dev, chipselect, spi_slv->mode,
+				    mode_changed, cs_changed);
 
 	return 0;
 }
@@ -1412,6 +1421,8 @@ static int setup_se_xfer(struct spi_transfer *xfer,
 	spin_lock_irq(&mas->lock);
 	geni_se_setup_m_cmd(se, m_cmd, m_params);
 
+	trace_geni_spi_transfer(mas->dev, len, m_cmd);
+
 	if (mas->cur_xfer_mode == GENI_SE_DMA) {
 		if (m_cmd & SPI_RX_ONLY)
 			geni_se_rx_init_dma(se, sg_dma_address(xfer->rx_sg.sgl),
@@ -1465,6 +1476,8 @@ static irqreturn_t geni_spi_isr(int irq, void *data)
 
 	if (!m_irq && !dma_tx_status && !dma_rx_status)
 		return IRQ_NONE;
+
+	trace_geni_spi_irq(mas->dev, m_irq, dma_tx_status, dma_rx_status);
 
 	if (m_irq & (M_CMD_OVERRUN_EN | M_ILLEGAL_CMD_EN | M_CMD_FAILURE_EN |
 		     M_RX_FIFO_RD_ERR_EN | M_RX_FIFO_WR_ERR_EN |


### PR DESCRIPTION
## Summary

Follow-up to the review of #79:

- remove the obsolete `&pon_resin` override retained by the integration replay
- restore the `DMA_PRIVATE` capability in `gpi.c`
- restore the existing GENI SPI tracepoints while retaining the SP11 paired-QSPI implementation
- advance the staging package ABI to `0sp11v21` so the corrected test kernel can coexist with v20

## Scope

This PR deliberately targets the existing `-sp11` staging branch so it can serve as a consistent, testable SP11 reference. It is not intended to be applied wholesale to the shared release line. Mergeable pieces can be recreated as separate topic branches from `jg/ubuntu-qcom-x1e-7.2.y`, with shared-driver changes gated to `microsoft,denali` where needed.

This validation applies to the exact head of this PR. It does not make a qualification claim for the separate USB4 topic branches or PRs.

## QSPI re-evaluation

The large driver diff in the replay initially looked like two stale complete files. A blob-level comparison showed that the phase55 preimages are byte-for-byte identical to the current 7.2.2 release-line driver blobs. The large diff is a consequence of replay order: the compact x1e-nixos QSPI implementation was applied first, then replaced by the different SP11 phase55 implementation.

Moving back to the compact path here would discard the paired TX/RX and event-completion behaviour used by the MSHW0485 path. This correction therefore retains the phase55 behaviour and restores only the two verified baseline regressions above. A clean QSPI topic split can be rebuilt from the release branch separately.

## Validation

Validated at exact head `116cef4df36a03c1f81056521fdd7f1aa11ee347` (tree `e00cbc28407c8e2279ab1722817becf521020f3c`):

- `scripts/checkpatch.pl --strict --git 4768136761aa..HEAD`: no warnings or errors
- `git diff --check 4768136761aa..HEAD`
- ARM64 `ubuntu_x1e_defconfig`
- ARM64 `W=1` builds of `drivers/dma/qcom/gpi.o` and `drivers/spi/spi-geni-qcom.o`
- ARM64 builds of `qcom/x1e80100-microsoft-denali-oled.dtb` and `qcom/x1p64100-microsoft-denali.dtb`
- clean full ARM64 v21 Debian package build with Lexr and no incremental reuse
- all recorded SHA-256 checks passed for the signed image, modules, ABI headers, and common headers
- Debian metadata confirms matching ABI/version/architecture and the ABI-header dependency on the common-header package
- both supported SP11 DTBs are present in the modules package
- the corrected Stubble-wrapped v21 image is 22,877,184 bytes and contains one `.linux`, one `.hwids`, 39 `.dtbauto` sections, and one exact embedded match for the packaged Denali OLED DTB
- all four packages were installed together; both DTBs and both installed header trees were verified, with `7.2.0-jg-0sp11v19-qcom-x1e` retained as fallback
- the machine rebooted successfully into `7.2.2-jg-0sp11v21-qcom-x1e`
- boot logs show `SP11: QSPI using GPI DMA descriptor mode`, the expected paired DMA sync mapping, touchscreen controller initialization, the IPTS HIDRAW bridge, and the IPTSD virtual stylus
- the user confirms the changes on this PR branch are working and good to go on Surface Pro 11 hardware

The earlier v21 black-screen/restart was traced to a raw, non-Stubble EFI image produced by the build path, not to this kernel head. The corrected build and installation policy is tracked in [ooaklee/lexr.sh#6](https://github.com/ooaklee/lexr.sh/pull/6).
