### PR TITLE
arm64: dts: qcom: x1-denali: add volume keys

### DIFF
--- a/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi
+++ b/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi
@@ -20,7 +20,7 @@
 	gpio-keys {
 		compatible = "gpio-keys";
 
-		pinctrl-0 = <&hall_int_n_default>;
+		pinctrl-0 = <&hall_int_n_default>, <&kypd_vol_up_n>;
 		pinctrl-names = "default";
 
 		switch-lid {
@@ -29,6 +29,13 @@
 			linux,code = <SW_LID>;
 			wakeup-source;
 			wakeup-event-action = <EV_ACT_DEASSERTED>;
+		};
+
+		key-vol-up {
+			label = "volume_up";
+			gpios = <&pm8550_gpios 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_VOLUMEUP>;
+			wakeup-source;
 		};
 	};
 
@@ -996,6 +1003,14 @@
 		pins = "gpio11";
 		function = "normal";
 		power-source = <1>; /* 1.8V */
+	};
+
+	kypd_vol_up_n: kypd-vol-up-n-state {
+		pins = "gpio6";
+		function = "normal";
+		power-source = <1>; /* 1.8V */
+		bias-pull-up;
+		input-enable;
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi
+++ b/arch/arm64/boot/dts/qcom/x1-microsoft-denali.dtsi
@@ -20,8 +20,9 @@
 	gpio-keys {
 		compatible = "gpio-keys";
 
-		pinctrl-0 = <&hall_int_n_default>, <&kypd_vol_up_n>;
+		pinctrl-0 = <&hall_int_n_default>, <&kypd_vol_up_n>, <&kypd_vol_down_n>;
 		pinctrl-names = "default";
+		autorepeat;
 
 		switch-lid {
 			gpios = <&tlmm 2 GPIO_ACTIVE_LOW>;
@@ -35,6 +36,13 @@
 			label = "volume_up";
 			gpios = <&pm8550_gpios 6 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_VOLUMEUP>;
+			wakeup-source;
+		};
+
+		key-vol-down {
+			label = "volume_down";
+			gpios = <&pm8550_gpios 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_VOLUMEDOWN>;
 			wakeup-source;
 		};
 	};
@@ -1007,6 +1015,14 @@
 
 	kypd_vol_up_n: kypd-vol-up-n-state {
 		pins = "gpio6";
+		function = "normal";
+		power-source = <1>; /* 1.8V */
+		bias-pull-up;
+		input-enable;
+	};
+
+	kypd_vol_down_n: kypd-vol-down-n-state {
+		pins = "gpio8";
 		function = "normal";
 		power-source = <1>; /* 1.8V */
 		bias-pull-up;


### PR DESCRIPTION
## Summary

- describe the Surface Pro 11 volume-up key on PM8550 GPIO 6
- describe the Surface Pro 11 volume-down key on PM8550 GPIO 8
- enable autorepeat for the hardware volume rocker
- keep the shared `pon_resin` node disabled

## Scope and dependency

This is the first release-line topic extracted from the working `-sp11` staging branch after #81. It is based directly on `jg/ubuntu-qcom-x1e-7.2.y` at `032e174490d2` and has no topic-PR dependency.

The change is limited to `x1-microsoft-denali.dtsi`. It does not carry the canceled CL4/PSCI experiment, USB changes, touch, pen, camera, audio, battery, or shared-driver changes from the staging history. The existing Denali firmware paths, rfkill setting, reserved GPIOs, and display backlight support are already present in the target branch and are therefore not replayed here.

The volume-down staging replay had retained an obsolete `pon_resin` override. #81 removed that replay omission from the staging branch; this release-line topic starts from the final intended state and never adds the override.

## Provenance

The two focused commits retain links to the original SP11 integration work:

- volume-up: [070c486c1075](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/070c486c1075e3bd8def391d0bc9e596cdb1d131)
- volume-down: [247858bdd7ff](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/247858bdd7ff39f5b05c996b226ffda353058fd0)
- property-ordering fix folded into volume-down: [e3b4bf3577ab](https://github.com/ooaklee/linux_ms_dev_kit-sp11/commit/e3b4bf3577abb0715ff69df13db1a146acbb5d72)

The older `ooaklee` alias on the volume-down commits has been normalized to the contributor's signed identity, `Leon Silcott <leon@boasi.io>`.

## Validation

- `git diff --check 032e174490d2..HEAD`
- `scripts/checkpatch.pl --strict --git 032e174490d2..HEAD`: no errors or warnings
- clean ARM64 `ubuntu_x1e_defconfig` DT build with `CHECK_DTBS=y` and dtschema 2025.8
- `qcom/x1e80100-microsoft-denali-oled.dtb` builds successfully
- `qcom/x1p64100-microsoft-denali.dtb` builds successfully
- both compiled DTBs contain the volume-up and volume-down keys with the expected GPIOs/keycodes, and neither contains a `pon_resin` enablement
- the same final volume-key state was included in the #81 test kernel; it booted on Surface Pro 11 hardware and the changes were confirmed working

## Cross-device impact

There are no shared-driver or non-Denali DT changes in this PR. Both supported Surface Pro 11 DTBs include the common Denali file and were validated above; other X1E/X1P devices do not include it.
